### PR TITLE
Add styling for CoC UI elements

### DIFF
--- a/colors/lucius.vim
+++ b/colors/lucius.vim
@@ -754,6 +754,15 @@ hi link VimwikiHeader4 BSpecial
 hi link VimwikiHeader5 BConstant
 hi link VimwikiHeader6 BType
 
+" CoC:
+hi link CocErrorSign ErrorMsg
+hi link CocErrorFloat Pmenu
+hi link CocWarningSign WarningMsg
+hi link CocWarningFloat Pmenu
+hi link CocInfoSign MoreMsg
+hi link CocInfoFloat Pmenu
+hi link CocHintFloat Directory
+hi link CocHintFloat Pmenu
 
 " ============================================================================
 " Preset Commands:


### PR DESCRIPTION
Fix legibility issues for various inline menus and hints used by CoC completion and compiler messages. The default colors that CoC defines are not legible on the dark Pmenu color.

![Screen Shot 2020-05-06 at 23 16 34](https://user-images.githubusercontent.com/24086/81251266-d794d600-8ff0-11ea-9a41-8ecd5d860bd7.png)
